### PR TITLE
Add dockerized option of raintank-collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ The results of each test are then transfered back to the Raintank API where they
   ```
 docker run \
     -d \
-    --name raintank-collector \
     -p 8284:8284 \
-    -e "apiKey=<RAINTANK_API_KEY>" \
-    -e "name=<COLLECTOR_NAME>" \
+    -e "RAINTANK_apiKey=<RAINTANK_API_KEY>" \
+    -e "RAINTANK_collector_name=<COLLECTOR_NAME>" \
     monitoringartist/raintank-collector
   ```
   [![Dockerized Raintank collector](https://raw.githubusercontent.com/monitoringartist/docker-raintank-collector/master/doc/raintank-collector-monitoring-artist.gif)](https://github.com/monitoringartist/docker-raintank-collector)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The results of each test are then transfered back to the Raintank API where they
 3. Install the collector application - 2 options
 
   a.) Use dockerized version of Raintank collector
-  * Minimal ~30sec deployment:
+  * Minimal ~10sec deployment:
   ```
 docker run \
     -d \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run \
     -e "name=<COLLECTOR_NAME>" \
     monitoringartist/raintank-collector
   ```
-  ![Dockerized Raintank collector](https://raw.githubusercontent.com/monitoringartist/docker-raintank-collector/master/doc/raintank-collector-monitoring-artist.gif)
+  [![Dockerized Raintank collector](https://raw.githubusercontent.com/monitoringartist/docker-raintank-collector/master/doc/raintank-collector-monitoring-artist.gif)](https://github.com/monitoringartist/docker-raintank-collector)
   Visit https://github.com/monitoringartist/docker-raintank-collector for more information.
 
   b.) Use non containerized version of Raintank collector

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The results of each test are then transfered back to the Raintank API where they
 3. Install the collector application - 2 options
 
   a.) Use dockerized version of Raintank collector
-  Minimal ~30sec deployment:
+  * Minimal ~30sec deployment:
   ```
 docker run \
     -d \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,23 @@ The results of each test are then transfered back to the Raintank API where they
   * Click on your user name in the left navigation menu, then click the ApiKeys submenu option.
   * Enter the key name and click 'add'
   * be sure to note down the key generated as you will need it for the collector configuration file.
-3. Install the collector application
+3. Install the collector application - 2 options
+
+  a.) Use dockerized version of Raintank collector
+  Minimal ~30sec deployment:
+  ```
+docker run \
+    -d \
+    --name raintank-collector \
+    -p 8284:8284 \
+    -e "apiKey=<RAINTANK_API_KEY>" \
+    -e "name=<COLLECTOR_NAME>" \
+    monitoringartist/raintank-collector
+  ```
+  ![Dockerized Raintank collector](https://raw.githubusercontent.com/monitoringartist/docker-raintank-collector/master/doc/raintank-collector-monitoring-artist.gif)
+  Visit https://github.com/monitoringartist/docker-raintank-collector for more information.
+
+  b.) Use non containerized version of Raintank collector
   * Clone the repository
   ```
 git clone https://github.com/raintank/raintank-collector.git


### PR DESCRIPTION
I've published dockerized version of raintank-collector. People don't like current install option #25 - this docker image will be much faster (~30sec) option for them.
