### PR TITLE
add build command step

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ git clone https://github.com/raintank/raintank-collector.git
   * Install `raintank_probe`, which has taken over some of raintank_collector's functionality.
   ```
 go get github.com/raintank/raintank-probe
+go build github.com/raintank/raintank-probe
   ```
   * Copy `raintank-probe` to `raintank-collector`'s directory.
   ```


### PR DESCRIPTION
The `go get` command in the example wasn't enough for me, I had to also use `go build`before the binary for `raintank-probe` appeared which is required in the next step.
