### PR TITLE
Get body length for json payloads as number of bytes rather than numb…

### DIFF
--- a/checks/dns.js
+++ b/checks/dns.js
@@ -20,7 +20,7 @@ exports.execute = function(payload, service, config, timestamp, callback) {
         port: config.probeServerPort,
         path:  '/dns',
         method: 'POST',
-        headers: {'Content-Type': "application/json", 'Content-Length': post_body.length}
+        headers: {'Content-Type': "application/json", 'Content-Length': Buffer.byteLength(post_body, 'utf8')}
     }, function(response) {
         var body = '';
         response.on('data', function(d) {

--- a/checks/http.js
+++ b/checks/http.js
@@ -26,7 +26,7 @@ exports.execute = function(payload, service, config, timestamp, callback) {
         port: config.probeServerPort,
         path:  '/http',
         method: 'POST',
-        headers: {'Content-Type': "application/json", 'Content-Length': post_body.length}
+        headers: {'Content-Type': "application/json", 'Content-Length': Buffer.byteLength(post_body, 'utf8')}
     }, function(response) {
         var body = '';
         response.on('data', function(d) {

--- a/checks/https.js
+++ b/checks/https.js
@@ -26,7 +26,7 @@ exports.execute = function(payload, service, config, timestamp, callback) {
         port: config.probeServerPort,
         path:  '/https',
         method: 'POST',
-        headers: {'Content-Type': "application/json", 'Content-Length': post_body.length}
+        headers: {'Content-Type': "application/json", 'Content-Length': Buffer.byteLength(post_body, 'utf8')}
     }, function(response) {
         var body = '';
         response.on('data', function(d) {

--- a/checks/ping.js
+++ b/checks/ping.js
@@ -23,7 +23,7 @@ exports.execute = function(payload, service, config, timestamp, callback) {
         port: config.probeServerPort,
         path:  '/ping',
         method: 'POST',
-        headers: {'Content-Type': "application/json", 'Content-Length': post_body.length}
+        headers: {'Content-Type': "application/json", 'Content-Length': Buffer.byteLength(post_body, 'utf8')}
     }, function(response) {
         var body = '';
         response.on('data', function(d) {


### PR DESCRIPTION
…er of chars

If a JSON payload from a monitor has a non-ASCII utf8 character in it, the content-length of the body will be incorrect and the JSON will fail to parse because it terminates early. This is an unusual occurrence, but a check fitting that description was added sometime last night/early this morning, and it was causing raintank-probe to restart constantly. This changes the collector to report the content length as the number of bytes rather than number of characters, to handle this unusual case.
